### PR TITLE
adding ability to configure multiple workers in the routes file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
     slop (3.6.0)
     thor (0.19.1)
     thread_safe (0.3.4)
+    timecop (0.7.1)
     timers (1.1.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -97,3 +98,4 @@ DEPENDENCIES
   pry
   rake
   rspec (~> 3.1)
+  timecop (~> 0.7.1)

--- a/lib/emque/consuming/application.rb
+++ b/lib/emque/consuming/application.rb
@@ -87,7 +87,7 @@ module Emque
         require_relative File.join(self.class.root, "config", "routes.rb")
 
         self.manager = Emque::Consuming::Adapter.manager(consuming_adapter).new(
-          Emque::Consuming::Application.application.router.topic_mapping
+          Emque::Consuming::Application.application.router
         )
 
         self.error_tracker = Emque::Consuming::ErrorTracker.new(

--- a/lib/emque/consuming/consumer.rb
+++ b/lib/emque/consuming/consumer.rb
@@ -1,3 +1,4 @@
+require "active_support"
 require "active_support/core_ext"
 require "oj"
 require_relative "consumer/common"

--- a/lib/emque/consuming/kafka/manager.rb
+++ b/lib/emque/consuming/kafka/manager.rb
@@ -9,8 +9,8 @@ module Emque
           logger.error "Kafka Manager: actor_died - #{actor.inspect} died: #{reason}"
         end
 
-        def initialize(topic_mapping)
-          self.topic_mapping = topic_mapping
+        def initialize(router)
+          self.topic_mapping = router.topic_mapping
           initialize_workers
         end
 
@@ -39,6 +39,7 @@ module Emque
         attr_accessor :workers, :shutdown, :topic_mapping
 
         def initialize_workers
+          # NOTE: this does not yet support multiple workers
           self.workers = [].tap { |workers|
             topic_mapping.keys.each do |topic|
               workers << Emque::Consuming::Kafka::Worker.new_link(topic)

--- a/lib/emque/consuming/router.rb
+++ b/lib/emque/consuming/router.rb
@@ -35,15 +35,20 @@ module Emque
         end
       end
 
+      def workers(topic)
+        mappings[topic.to_sym].map(&:workers).max
+      end
+
       private
 
       attr_accessor :mappings
 
       class Mapping
-        attr_reader :consumer, :topic
+        attr_reader :consumer, :topic, :workers
 
         def initialize(mapping, &block)
           self.topic = mapping.keys.first
+          self.workers = mapping.fetch(:workers, 1)
           self.consumer = mapping.values.first
           self.mapping = {}
 
@@ -61,7 +66,7 @@ module Emque
         private
 
         attr_accessor :mapping
-        attr_writer :consumer, :topic
+        attr_writer :consumer, :topic, :workers
       end
     end
   end

--- a/lib/emque/consuming/tasks.rb
+++ b/lib/emque/consuming/tasks.rb
@@ -1,0 +1,44 @@
+module Emque
+  module Consuming
+    class Tasks
+      include Rake::DSL if defined? Rake::DSL
+
+      def install_tasks
+        namespace :emque do
+          desc "Show the available routes"
+          task :routes do
+            require "table_print"
+            tp(
+              [].tap { |routes|
+                Emque::Consuming.application.new
+                router = Emque::Consuming.application.router
+                mappings = router.instance_eval { @mappings }
+
+                mappings.each { |topic, maps|
+                  maps.each { |mapping|
+                    mapping.instance_eval { @mapping }.each { |route, method|
+                      routes << {
+                        :route => route,
+                        :topic => topic,
+                        :consumer => mapping.consumer,
+                        :method => method,
+                        :workers => router.workers(topic)
+                      }
+                    }
+                  }
+                }
+              },
+              {:route => {:width => 50}},
+              :topic,
+              :consumer,
+              :method,
+              :workers
+            )
+          end
+        end
+      end
+    end
+  end
+end
+
+Emque::Consuming::Tasks.new.install_tasks


### PR DESCRIPTION
Example:

``` ruby
  topic "cheese" => CheeseConsumer, :workers => 3 do
    map "cheese.new" => "eat"
    map "cheese.updated" => "try_again"
  end

  topic "beer" => BeerConsumer do
    map "beer.new" => "drink"
    map "beer.deleted" => "ask_for_more"
  end
```
