### PR TITLE
Fixes #37 to not stop the pipe when an error occurs

### DIFF
--- a/lib/emque/consuming/consumer/common.rb
+++ b/lib/emque/consuming/consumer/common.rb
@@ -27,6 +27,7 @@ module Emque
         def pipe_config
           @pipe_config ||= Pipe::Config.new(
             :error_handlers => [method(:handle_error)],
+            :raise_on_error => false,
             :stop_on => ->(msg, _, _) { !(msg.respond_to?(:continue?) && msg.continue?) }
           )
         end


### PR DESCRIPTION
Let the pipe continue on if an error is raised. The error handlers will still log the error.