### PR TITLE
Update versions of virtus and bunny to latest.

### DIFF
--- a/emque-consuming.gemspec
+++ b/emque-consuming.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "celluloid", "0.16.0"
   spec.add_dependency "dante",     "~> 0.2.0"
   spec.add_dependency "oj",        "~> 2.11.4"
-  spec.add_dependency "virtus",    "~> 1.0.4"
+  spec.add_dependency "virtus",    "~> 1.0"
   spec.add_dependency "puma",      "~> 2.11.1"
   spec.add_dependency "pipe-ruby", "~> 0.2.0"
   spec.add_dependency "inflecto",  "~> 0.0.2"
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake",    "~> 10.4.2"
   spec.add_development_dependency "rspec",   "~> 3.2.0"
-  spec.add_development_dependency "bunny",   "~> 1.4.1"
+  spec.add_development_dependency "bunny",   "~> 1.7"
   spec.add_development_dependency "timecop", "~> 0.7.1"
   spec.add_development_dependency "daemon_controller", "~> 1.2.0"
 end

--- a/lib/emque/consuming/version.rb
+++ b/lib/emque/consuming/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Consuming
-    VERSION = "1.0.0.beta2"
+    VERSION = "1.0.0.beta3"
   end
 end


### PR DESCRIPTION
For bunny, we need to stick with v1.7 and not jump to version 2+. bunny v2
drops support for Ruby 1.9 and while on the consuming side, that is not a
problem, we still support producing on 1.9 and the bunny versions are not
recommended to be mixed (https://github.com/ruby-amqp/bunny/blob/master/ChangeLog.md#changes-between-bunny-200-and-210).
So, we wouldn't want to keep producing with 1.7 and consuming with 2+.

For virtus, matching emque-pruducing's gemspec.