### PR TITLE
Re-route failed messages to error queue for inspection and provide on-demand error retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+## 1.0.0.beta4 — (unreleased)
+
+### BREAKING CHANGE - New Queue Names
+Applications updating to this version will have new queue names in RabbitMQ.
+After starting up, messages will need to be manually moved
+from the old queue to the new one.
+
+### Failed Message Routing
+Messages that are not acknolwedged due to a consumer error will now be routed
+into a `service_name.error` queue. These can then be inspected and be discarded,
+purged, or manually moved back to the primary queue for re-processing.

--- a/emque-consuming.gemspec
+++ b/emque-consuming.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake",    "~> 10.4.2"
-  spec.add_development_dependency "rspec",   "~> 3.2.0"
+  spec.add_development_dependency "rspec",   "~> 3.3"
   spec.add_development_dependency "bunny",   "~> 1.7"
   spec.add_development_dependency "timecop", "~> 0.7.1"
   spec.add_development_dependency "daemon_controller", "~> 1.2.0"

--- a/lib/emque/consuming/adapters/rabbit_mq.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq.rb
@@ -14,6 +14,7 @@ module Emque
         def self.load
           require_relative "rabbit_mq/manager"
           require_relative "rabbit_mq/worker"
+          require_relative "rabbit_mq/retry_worker"
         end
 
         def self.manager

--- a/lib/emque/consuming/adapters/rabbit_mq/manager.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/manager.rb
@@ -76,7 +76,7 @@ module Emque
 
           def initialize_error_queue
             channel = @connection.create_channel
-            error_exchange = channel.fanout(
+            error_exchange = channel.direct(
               "#{config.app_name}.error",
               :durable => true,
               :auto_delete => false
@@ -89,6 +89,7 @@ module Emque
                 "x-dead-letter-exchange" => "#{config.app_name}.error"
               }
             ).bind(error_exchange)
+            channel.close
           end
 
           def new_worker(topic)

--- a/lib/emque/consuming/adapters/rabbit_mq/manager.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/manager.rb
@@ -17,6 +17,7 @@ module Emque
 
           def start
             setup_connection
+            initialize_error_queue
             initialize_workers
             logger.info "RabbitMQ Manager: starting #{worker_count} workers..."
             workers(:flatten => true).each do |worker|
@@ -67,6 +68,20 @@ module Emque
                 end
               end
             }
+          end
+
+          def initialize_error_queue
+            channel = @connection.create_channel
+            error_exchange = channel.fanout(
+              "#{config.app_name}.error",
+              :durable => true,
+              :auto_delete => false
+            )
+            channel.queue(
+              "#{config.app_name}.error",
+              :durable => true,
+              :auto_delete => false,
+            ).bind(error_exchange)
           end
 
           def new_worker(topic)

--- a/lib/emque/consuming/adapters/rabbit_mq/manager.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/manager.rb
@@ -76,13 +76,13 @@ module Emque
 
           def initialize_error_queue
             channel = @connection.create_channel
-            error_exchange = channel.direct(
+            error_exchange = channel.fanout(
               "#{config.app_name}.error",
               :durable => true,
               :auto_delete => false
             )
             channel.queue(
-              "#{config.app_name}.error",
+              "emque.#{config.app_name}.error",
               :durable => true,
               :auto_delete => false,
               :arguments => {

--- a/lib/emque/consuming/adapters/rabbit_mq/manager.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/manager.rb
@@ -55,6 +55,10 @@ module Emque
             flatten ? @workers.values.flatten : @workers
           end
 
+          def retry_errors
+            RetryWorker.new(@connection).retry_errors
+          end
+
           private
 
           attr_writer :workers
@@ -81,6 +85,9 @@ module Emque
               "#{config.app_name}.error",
               :durable => true,
               :auto_delete => false,
+              :arguments => {
+                "x-dead-letter-exchange" => "#{config.app_name}.error"
+              }
             ).bind(error_exchange)
           end
 

--- a/lib/emque/consuming/adapters/rabbit_mq/retry_worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/retry_worker.rb
@@ -1,0 +1,68 @@
+require "bunny"
+
+module Emque
+  module Consuming
+    module Adapters
+      module RabbitMq
+        class RetryWorker
+          include Emque::Consuming::Helpers
+
+          def initialize(connection)
+            self.channel = connection.create_channel
+            self.queue = channel.queue(
+              "#{config.app_name}.error",
+              :durable => true,
+              :auto_delete => false,
+              :arguments => {
+                "x-dead-letter-exchange" => "#{config.app_name}.error"
+              }
+            )
+          end
+
+          attr_accessor :channel, :queue
+
+          def retry_errors
+            logger.info "RabbitMQ RetryWorker: starting"
+            loop do
+              delivery_info, properties, payload = queue.pop(
+                {:manual_ack => true}
+              )
+              break if delivery_info.nil? && properties.nil? && payload.nil?
+              retry_message(delivery_info, properties, payload)
+            end
+            logger.info "RabbitMQ RetryWorker: done"
+          end
+
+          private
+
+          attr_accessor :connection, :channel
+
+          def error_queue
+            channel.queue(
+              "emque.#{config.app_name}.error",
+              :durable => true,
+              :auto_delete => false,
+              :arguments => {
+                "x-dead-letter-exchange" => "#{config.app_name}.error"
+              }
+            )
+          end
+
+>>>>>>> 8261078... blah
+          def retry_message(delivery_info, metadata, payload)
+            begin
+              logger.info "RabbitMQ RetryWorker: processing message #{payload}"
+              message = Emque::Consuming::Message.new(
+                :original => payload
+              )
+              ::Emque::Consuming::Consumer.new.consume(:process, message)
+              channel.ack(delivery_info.delivery_tag)
+            rescue
+              channel.nack(delivery_info.delivery_tag)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/emque/consuming/adapters/rabbit_mq/retry_worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/retry_worker.rb
@@ -48,7 +48,7 @@ module Emque
               )
               ::Emque::Consuming::Consumer.new.consume(:process, message)
               channel.ack(delivery_info.delivery_tag)
-            rescue
+            rescue StandardError
               channel.nack(delivery_info.delivery_tag)
             end
           end

--- a/lib/emque/consuming/adapters/rabbit_mq/worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/worker.rb
@@ -68,10 +68,7 @@ module Emque
             begin
               logger.info "#{log_prefix} processing message #{payload}"
               message = Emque::Consuming::Message.new(
-                :offset => nil,
-                :original => payload,
-                :partition => nil,
-                :topic => topic.to_sym
+                :original => payload
               )
               ::Emque::Consuming::Consumer.new.consume(:process, message)
               channel.ack(delivery_info.delivery_tag)

--- a/lib/emque/consuming/adapters/rabbit_mq/worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/worker.rb
@@ -72,7 +72,7 @@ module Emque
               )
               ::Emque::Consuming::Consumer.new.consume(:process, message)
               channel.ack(delivery_info.delivery_tag)
-            rescue
+            rescue StandardError
               channel.nack(delivery_info.delivery_tag)
             end
           end

--- a/lib/emque/consuming/adapters/rabbit_mq/worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/worker.rb
@@ -25,14 +25,20 @@ module Emque
             #        a new channel in each worker.
             # https://github.com/jhbabon/amqp-celluloid/blob/master/lib/consumer.rb
             self.channel = connection.create_channel
-            channel.prefetch(config.adapter.options[:prefetch]) if config.adapter.options[:prefetch]
+
+            if config.adapter.options[:prefetch]
+              channel.prefetch(config.adapter.options[:prefetch])
+            end
 
             self.queue =
               channel
                 .queue(
-                  "#{config.app_name}.#{topic}",
+                  "emque.#{config.app_name}.#{topic}",
                   :durable => config.adapter.options[:durable],
-                  :auto_delete => config.adapter.options[:auto_delete]
+                  :auto_delete => config.adapter.options[:auto_delete],
+                  :arguments => {
+                    "x-dead-letter-exchange" => "#{config.app_name}.error"
+                  }
                 )
                 .bind(
                   channel.fanout(topic, :durable => true, :auto_delete => false)
@@ -59,15 +65,19 @@ module Emque
           attr_accessor :name, :channel, :queue
 
           def process_message(delivery_info, metadata, payload)
-            logger.info "#{log_prefix} processing message #{payload}"
-            message = Emque::Consuming::Message.new(
-              :offset => nil,
-              :original => payload,
-              :partition => nil,
-              :topic => topic.to_sym
-            )
-            ::Emque::Consuming::Consumer.new.consume(:process, message)
-            channel.ack(delivery_info.delivery_tag)
+            begin
+              logger.info "#{log_prefix} processing message #{payload}"
+              message = Emque::Consuming::Message.new(
+                :offset => nil,
+                :original => payload,
+                :partition => nil,
+                :topic => topic.to_sym
+              )
+              ::Emque::Consuming::Consumer.new.consume(:process, message)
+              channel.ack(delivery_info.delivery_tag)
+            rescue
+              channel.nack(delivery_info.delivery_tag)
+            end
           end
 
           def log_prefix

--- a/lib/emque/consuming/command_receivers/unix_socket.rb
+++ b/lib/emque/consuming/command_receivers/unix_socket.rb
@@ -95,6 +95,7 @@ errors clear                  # reset the error count to 0
 errors down                   # decrease the acceptable error threshold by 1
 errors expire_after <seconds> # changes the expiration time for future errors
 errors up                     # increase the acceptable error threshold by 1
+errors retry                  # Reprocesses all messages in the error queue
 restart                       # restart all workers
 stop                          # turn the application off
 -------

--- a/lib/emque/consuming/consumer.rb
+++ b/lib/emque/consuming/consumer.rb
@@ -23,7 +23,7 @@ module Emque
 
       def route(message)
         Emque::Consuming.application.router.route(
-          message.topic,
+          message.values.fetch(:metadata).fetch(:topic),
           message.values.fetch(:metadata).fetch(:type),
           message
         )

--- a/lib/emque/consuming/control/errors.rb
+++ b/lib/emque/consuming/control/errors.rb
@@ -4,7 +4,7 @@ module Emque
       class Errors
         include Emque::Consuming::Helpers
 
-        COMMANDS = [:clear, :down, :expire_after, :up]
+        COMMANDS = [:clear, :down, :expire_after, :up, :retry]
 
         def clear
           app.error_tracker.occurrences.clear
@@ -26,6 +26,10 @@ module Emque
 
         def up
           config.error_limit = app.error_tracker.limit += 1
+        end
+
+        def retry
+          app.manager.retry_errors
         end
 
         def respond_to?(method)

--- a/lib/emque/consuming/version.rb
+++ b/lib/emque/consuming/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Consuming
-    VERSION = "1.0.0.beta3"
+    VERSION = "1.0.0.beta4"
   end
 end

--- a/spec/control/errors_spec.rb
+++ b/spec/control/errors_spec.rb
@@ -159,4 +159,12 @@ describe Emque::Consuming::Control::Errors do
       expect { control.up }.to change { config.error_limit }.to(2)
     end
   end
+
+  describe "#retry" do
+    it "starts the retry worker" do
+      control = Emque::Consuming::Control::Errors.new
+      config = Emque::Consuming::Configuration.new
+      control.retry
+    end
+  end
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -18,6 +18,7 @@ module Emque
           def stop; end
           def worker(topic:, command:); end
           def workers(flatten: false); end
+          def retry_errors; end
         end
       end
     end


### PR DESCRIPTION
Leveraging what RabbitMQ provides, this update adds error handling and retry capabilities into emque and eliminates the auto-shutdown.

In diving further into RabbitMQ and AMPQ, it has become evident that error handing is something that is typically solved in this community using `basic.reject` or `basic.nack` in combination with dead lettering.

```
Messages from a queue can be 'dead-lettered'; that is, republished to another exchange when any of the following events occur:

The message is rejected (basic.reject or basic.nack) with requeue=false,
The TTL for the message expires; or
The queue length limit is exceeded
```
REF: http://www.rabbitmq.com/dlx.html

> this is what RabbitMQ's basic.reject will do: if you supply requeue=false it will discard the message (this is in lieu of dead-lettering it, until we have a dead letter feature); if you supply requeue=true, it will release it back on to the queue, to be delivered again.

> but, given a dead-letter mechanism, it will mean unprocessable messages can be picked up elsewhere for diagnosis.

REF: http://www.rabbitmq.com/blog/2010/08/03/well-ill-let-you-go-basicreject-in-rabbitmq/

Several questions to be addressed still

  1. Use `basic.reject` or `basic.nack`?


  2. Should emque be responsible for establishing dead letter exchanges/queue or should that be handled outside (for example, Hutch leaves it up to the server policies: https://github.com/gocardless/hutch/issues/136)



  3. One dead letter exchange AND one dead letter queue PER emque consumer queue means that the number of queues will double, is there a smarter, smaller set of dead letter queues to consider?

  Originally we decided against having both an error and a retry queue because it would lead to an explosion of queues (tripling). But, if we can handle BOTH error and retry in the dead letter queue, then perhaps the doubling of queues is acceptable.

  4. Once the message gets into the dead letter queue, what will we do with it?

  By tracking retries.  [x-death](https://www.rabbitmq.com/dlx.html) can be used to track failures.

