### PR TITLE
Cap the maximum # of workers based on known bottlenecks

### DIFF
--- a/lib/emque/consuming/adapters/rabbit_mq/manager.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/manager.rb
@@ -59,6 +59,10 @@ module Emque
             RetryWorker.new(@connection).retry_errors
           end
 
+          def worker_count
+            workers(:flatten => true).size
+          end
+
           private
 
           attr_writer :workers
@@ -99,10 +103,6 @@ module Emque
           def setup_connection
             @connection = Bunny.new(config.adapter.options[:url])
             @connection.start
-          end
-
-          def worker_count
-            workers(:flatten => true).size
           end
         end
       end

--- a/lib/emque/consuming/command_receivers/http_server.rb
+++ b/lib/emque/consuming/command_receivers/http_server.rb
@@ -56,10 +56,12 @@ module Emque
                   return render_status
                 end
               else
-                if req[2].is_a?(String) &&
-                   app.manager.workers.has_key?(req[2].to_sym) &&
-                   runner.control.workers(*req[2..-1]) == true
-                  return render_status
+                if req[2].is_a?(String) && app.manager.workers.has_key?(req[2].to_sym)
+                   if runner.control.workers(*req[2..-1]) == true
+                     return render_status
+                   else
+                     return render_400
+                   end
                 end
               end
             end
@@ -69,6 +71,18 @@ module Emque
 
           def render_404
             [404, {}, ["Not Found"]]
+          end
+
+          def render_400
+            [
+              400,
+              {},
+              [
+                "#{config.max_workers.fetch(:error_message) {
+                  "Max workers reached."
+                }}"
+              ]
+            ]
           end
 
           def render_status(additional = {})

--- a/lib/emque/consuming/configuration.rb
+++ b/lib/emque/consuming/configuration.rb
@@ -5,7 +5,7 @@ module Emque
     class Configuration
       attr_accessor :app_name, :adapter, :error_handlers, :error_limit,
         :error_expiration, :status, :status_port, :status_host, :socket_path,
-        :shutdown_handlers
+        :shutdown_handlers, :max_workers
       attr_writer :env, :log_level
 
       def initialize
@@ -14,6 +14,10 @@ module Emque
         @error_limit        = 5
         @error_expiration   = 3600 # 60 minutes
         @log_level          = nil
+        # See README.md for guidance on setting max_workers
+        @max_workers        = {
+          :limit => 10, :error_message => "Max workers reached."
+        }
         @status_port        = 10000
         @status_host        = "0.0.0.0"
         @status             = :off # :on
@@ -47,6 +51,7 @@ module Emque
             :error_limit,
             :error_expiration,
             :log_level,
+            :max_workers,
             :status_port,
             :status_host,
             :status,

--- a/lib/emque/consuming/control/workers.rb
+++ b/lib/emque/consuming/control/workers.rb
@@ -11,7 +11,11 @@ module Emque
         end
 
         def up(topic)
-          app.manager.worker(topic: topic.to_sym, command: :up)
+          if app.manager.worker_count < config.max_workers.fetch(:limit)
+            app.manager.worker(topic: topic.to_sym, command: :up)
+          else
+            :max_worker_limit_reached
+          end
         end
 
         def respond_to?(method)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -14,6 +14,20 @@ describe Emque::Consuming::Configuration do
     end
   end
 
+  describe "#max_workers" do
+    it "includes a reasonable, if arbitrary, default limit" do
+      config = Emque::Consuming::Configuration.new
+
+      expect(config.max_workers.fetch(:limit)).to eq 10
+    end
+
+    it "includes a generic, though still helpful, default message" do
+      config = Emque::Consuming::Configuration.new
+
+      expect(config.max_workers.fetch(:error_message)).to eq "Max workers reached."
+    end
+  end
+
   describe "#to_hsh" do
     it "returns a hash" do
       config = Emque::Consuming::Configuration.new
@@ -23,8 +37,8 @@ describe Emque::Consuming::Configuration do
     it "returns the value of all the accessors" do
       accessors = [
         :app_name, :adapter, :env, :error_handlers, :error_limit,
-        :error_expiration, :log_level, :status_port, :status_host, :status,
-        :socket_path, :shutdown_handlers
+        :error_expiration, :log_level, :max_workers, :status_port,
+        :status_host, :status, :socket_path, :shutdown_handlers
       ]
       config = Emque::Consuming::Configuration.new
 

--- a/spec/control/workers_spec.rb
+++ b/spec/control/workers_spec.rb
@@ -1,0 +1,66 @@
+require "spec_helper"
+require "ostruct"
+
+describe Emque::Consuming::Control::Workers do
+  describe "#down" do
+    it "decreases the manager's worker count" do
+      topic = :events
+      control = Emque::Consuming::Control::Workers.new
+      app = OpenStruct.new
+      config = Emque::Consuming::Configuration.new
+      app.manager = OpenStruct.new
+      application = OpenStruct.new
+      application.config = config
+      application.instance = app
+
+      expect(control).to receive(:app).and_return(app)
+      expect(app).to receive(:manager).at_least(1).times
+      expect(app.manager).to receive(:worker).with(topic: topic, command: :down)
+
+      control.down(topic)
+    end
+  end
+
+  describe "#up" do
+    context "max workers is less than amount defined in application config" do
+      it "instructs the manager to increase the worker count" do
+        topic = :events
+        control = Emque::Consuming::Control::Workers.new
+        app = OpenStruct.new
+        config = Emque::Consuming::Configuration.new
+        app.manager = OpenStruct.new
+        application = OpenStruct.new
+        application.config = config
+        application.instance = app
+
+        expect(control).to receive(:app).at_least(1).times.and_return(app)
+        expect(app).to receive(:manager).at_least(1).times
+        expect(app.manager).to receive(:worker).with(topic: topic, command: :up)
+        expect(app.manager).to receive(:worker_count).and_return(5)
+
+        control.up(topic)
+      end
+    end
+
+    context "max workers equal to amount defined in application config" do
+      it "does not instruct the manager to increase the worker count" do
+        topic = :events
+        control = Emque::Consuming::Control::Workers.new
+        app = OpenStruct.new
+        config = Emque::Consuming::Configuration.new
+        app.manager = OpenStruct.new
+        application = OpenStruct.new
+        application.config = config
+        application.instance = app
+
+        expect(control).to receive(:app).at_least(1).times.and_return(app)
+        expect(app).to receive(:manager).at_least(1).times
+        expect(app.manager).to receive(:worker_count).and_return(15)
+
+        expect(app.manager).to_not receive(:worker).with(topic: topic, command: :up)
+
+        control.up(topic)
+      end
+    end
+  end
+end


### PR DESCRIPTION
There is currently no formula for determining the "ceiling" for the # of workers in a given Emque process. So, as Rabbit messages become queued up and a developer attempts to increase workers in order to process the backlog, said developer will inevitably run into another constraint. Some of these may be unforeseen, but some are known ahead of time and can be declared.

For example, services using the Sequel gem have a maximum number of database connections defined in a given pool (default is 4, and the default timeout is 10s). So, in theory, this limit, which is well defined, could be used as a cap for the number of workers in a given Emque process since we know that if we exceed that limit, Bad Things will happen.

So, the question then becomes how this behavior is exposed to the developer. My impression is that for the Sequel example, if the Emque process can observe it's usage of Sequel, it can determine the max connection pool size and use that to limit it's total number of workers. A developer will not need to specify this anywhere in their Emque config (possibly duplicating their Sequel config). And any attempts to raise the number of workers above the limit will be met with a detailed message indicating why they may not:

> Max worker limit reached. Bottleneck: Sequel gem in use. Max DB connections set to 4. Please increase Sequel gem connections before attempting to increase workers.

How will this be implemented?

The RabbitMQ Manager class is responsible for increasing and decreasing the workers, and the `Control::Worker` class is a layer of abstraction over the adapter. The `Control::Worker` class has the following method signature:

``` ruby
def up(topic)
  app.manager.worker(topic: topic.to_sym, command: :up)
end
```

And the adapter's `Manager` class receives it as follows:

``` ruby
def worker(topic:, command:)
  if workers.has_key?(topic)
    case command
      when :down
        worker = workers[topic].pop
        worker.stop if worker
      when :up
        workers[topic] << new_worker(topic)
        workers[topic].last.async.start
    end
  end
end
```

The Adapters `Manager` should not have any knowledge of the environment is operates in. However, the `Control::Workers` class could have knowledge of the environment either by automatically checking defined limits in the environment or by using a configuration option passed in. E.g.:

``` ruby
def up
  if config.max_workers < app.manager.worker_count
    app.manager.worker(topic: topic.to_sym, command: :up)
  else
    # TBD - not sure what the correct type of response should be here
  end
end
```

That would manage the worker scaling on the emque side. In terms of getting the correct error message back to emque-web, well...still working on figuring that out.
