### PR TITLE
Update for Ruby 2.3 and later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 rvm:
-  - 2.1.6
-  - 2.2.2
   - 2.3.1
+  - 2.4.4
+  - 2.5.1
 script: bundle exec rake
 notifications:
   recipients:
     - shane@teamsnap.com
-    - dan@sensiblesitters.com
+    - ryan.williams@teamsnap.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Emque Consuming CHANGELOG
 
+- [Update minimum Ruby version to 2.3](https://github.com/emque/emque-consuming/pull/68) 1.3.0
 - [Update the oj gem to 2.18.5](https://github.com/emque/emque-consuming/pull/67) 1.2.4
 - [Add error logging when an exception is thrown.](https://github.com/emque/emque-consuming/pull/65) 1.2.3
 - [Remove double ack when consuming a message and ending up in an error state. This was causing consumers to die silently.](https://github.com/emque/emque-consuming/pull/59) 1.2.1

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add this line to your application's Gemfile:
 ```ruby
 gem "emque-consuming"
 # make sure you have bunny for rabbitmq unless you're using a custom adapter
-gem "bunny", "~> 1.7"
+gem "bunny", "~> 2.11.0"
 ```
 
 And then execute:

--- a/emque-consuming.gemspec
+++ b/emque-consuming.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.1"
+  spec.required_ruby_version = ">= 2.3"
 
   spec.add_dependency "celluloid", "0.16.0"
   spec.add_dependency "dante",     "~> 0.2.0"
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake",    "~> 10.4.2"
   spec.add_development_dependency "rspec",   "~> 3.3"
-  spec.add_development_dependency "bunny",   "~> 1.7"
+  spec.add_development_dependency "bunny",   "~> 2.11.0"
   spec.add_development_dependency "timecop", "~> 0.7.1"
   spec.add_development_dependency "daemon_controller", "~> 1.2.0"
 end

--- a/lib/emque/consuming/version.rb
+++ b/lib/emque/consuming/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Consuming
-    VERSION = "1.2.4"
+    VERSION = "1.3.0"
   end
 end


### PR DESCRIPTION
Update the minimum Ruby since [Support of Ruby 2.2 has ended](https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/).