### PR TITLE
Update oj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Emque Consuming CHANGELOG
 
+- [Update the oj gem 3.6](https://github.com/emque/emque-consuming/pull/69) 1.3.1
 - [Update minimum Ruby version to 2.3](https://github.com/emque/emque-consuming/pull/68) 1.3.0
 - [Update the oj gem to 2.18.5](https://github.com/emque/emque-consuming/pull/67) 1.2.4
 - [Add error logging when an exception is thrown.](https://github.com/emque/emque-consuming/pull/65) 1.2.3

--- a/emque-consuming.gemspec
+++ b/emque-consuming.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["oss@teamsnap.com"]
   spec.summary       = %q{Microservices framework for Ruby}
   spec.summary       = %q{Microservices framework for Ruby}
-  spec.homepage      = "https://github.com/teamsnap/emque-consuming"
+  spec.homepage      = "https://github.com/emque/emque-consuming"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)

--- a/emque-consuming.gemspec
+++ b/emque-consuming.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "celluloid", "0.16.0"
   spec.add_dependency "dante",     "~> 0.2.0"
-  spec.add_dependency "oj",        "~> 2.18.5"
+  spec.add_dependency "oj",        "~> 3.6"
   spec.add_dependency "virtus",    "~> 1.0"
   spec.add_dependency "puma",      "~> 2.12.0"
   spec.add_dependency "pipe-ruby", "~> 0.2.0"

--- a/lib/emque/consuming/version.rb
+++ b/lib/emque/consuming/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Consuming
-    VERSION = "1.3.0"
+    VERSION = "1.3.1"
   end
 end


### PR DESCRIPTION
In order to update applications to Ruby 2.4+ will require an update ActiveSupport 5+ which requires an update to oj 3+.