### PR TITLE
Update Puma dependency to build on Ruby 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Emque Consuming CHANGELOG
 
+- [Update the puma gem to allow v3](https://github.com/emque/emque-consuming/pull/72) 1.5.0
 - [Disable pipe-ruby `raise_on_error` option to prevent duplicate erorrs](https://github.com/emque/emque-consuming/pull/74) 1.4.0
 - [Update minimum Ruby version to 2.3](https://github.com/emque/emque-consuming/pull/68) 1.3.0
 - [Update the oj gem to 2.18.5](https://github.com/emque/emque-consuming/pull/67) 1.2.4

--- a/emque-consuming.gemspec
+++ b/emque-consuming.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dante",     "~> 0.2.0"
   spec.add_dependency "oj",        "~> 2.18.5"
   spec.add_dependency "virtus",    "~> 1.0"
-  spec.add_dependency "puma",      "~> 2.12.0"
+  spec.add_dependency "puma",      "~> 3.12"
   spec.add_dependency "pipe-ruby", "~> 0.2.0"
   spec.add_dependency "inflecto",  "~> 0.0.2"
 

--- a/lib/emque/consuming/version.rb
+++ b/lib/emque/consuming/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Consuming
-    VERSION = "1.4.0"
+    VERSION = "1.5.0"
   end
 end


### PR DESCRIPTION
Puma 2 fails to install on more recent environments including Ruby 2.5. It will also fail on Codeship's new Ubuntu bionic images.

https://github.com/puma/puma/issues/1380