### PR TITLE
Fix double errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
   - 2.3.1
-  - 2.4.4
-  - 2.5.1
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
 script: bundle exec rake
 notifications:
   recipients:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Emque Consuming CHANGELOG
 
+- [Disable pipe-ruby `raise_on_error` option to prevent duplicate erorrs](https://github.com/emque/emque-consuming/pull/74) 1.4.0
 - [Update minimum Ruby version to 2.3](https://github.com/emque/emque-consuming/pull/68) 1.3.0
 - [Update the oj gem to 2.18.5](https://github.com/emque/emque-consuming/pull/67) 1.2.4
 - [Add error logging when an exception is thrown.](https://github.com/emque/emque-consuming/pull/65) 1.2.3

--- a/lib/emque/consuming/consumer/common.rb
+++ b/lib/emque/consuming/consumer/common.rb
@@ -27,6 +27,7 @@ module Emque
         def pipe_config
           @pipe_config ||= Pipe::Config.new(
             :error_handlers => [method(:handle_error)],
+            :raise_on_error => false,
             :stop_on => ->(msg, _, _) { !(msg.respond_to?(:continue?) && msg.continue?) }
           )
         end

--- a/lib/emque/consuming/version.rb
+++ b/lib/emque/consuming/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Consuming
-    VERSION = "1.3.0"
+    VERSION = "1.4.0"
   end
 end


### PR DESCRIPTION
The raise_on_error setting, when enabled, causes pipe-ruby to notify error handlers twice for the error. Once for the original error and once for the rewritten pipe-ruby error. This is causing confusing error logs in emque services.

https://github.com/teamsnap/pipe-ruby/blob/1443f714cf819aac09507f3fa36669db7899a2e7/lib/pipe/reducer.rb#L45

