### PR TITLE
Reinstate pipe raise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Emque Consuming CHANGELOG
 
+- [Re-enable pipe-ruby `raise_on_error` option to fix automatic retries directing messages to the error queue](https://github.com/emque/emque-consuming/pull/) 1.6.0
 - [Update the puma gem to allow v3](https://github.com/emque/emque-consuming/pull/72) 1.5.0
 - [Disable pipe-ruby `raise_on_error` option to prevent duplicate erorrs](https://github.com/emque/emque-consuming/pull/74) 1.4.0
 - [Update minimum Ruby version to 2.3](https://github.com/emque/emque-consuming/pull/68) 1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Emque Consuming CHANGELOG
 
-- [Re-enable pipe-ruby `raise_on_error` option to fix automatic retries directing messages to the error queue](https://github.com/emque/emque-consuming/pull/) 1.6.0
+- [Re-enable pipe-ruby `raise_on_error` option to fix automatic retries directing messages to the error queue](https://github.com/emque/emque-consuming/pull/75) 1.6.0
 - [Update the puma gem to allow v3](https://github.com/emque/emque-consuming/pull/72) 1.5.0
 - [Disable pipe-ruby `raise_on_error` option to prevent duplicate erorrs](https://github.com/emque/emque-consuming/pull/74) 1.4.0
 - [Update minimum Ruby version to 2.3](https://github.com/emque/emque-consuming/pull/68) 1.3.0

--- a/lib/emque/consuming/adapters/rabbit_mq/delayed_message_worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/delayed_message_worker.rb
@@ -69,8 +69,6 @@ module Emque
               ::Emque::Consuming::Consumer.new.consume(:process, message)
               channel.ack(delivery_info.delivery_tag)
             rescue StandardError => exception
-              logger.error "#{log_prefix} #{exception.class}: #{exception.message}"
-              exception.backtrace.each { |bt| logger.error "#{log_prefix} #{bt}" }
               if retryable_errors.any? { |error| exception.class.to_s =~ /#{error}/ }
                 retry_error(delivery_info, metadata, payload, exception)
               else

--- a/lib/emque/consuming/adapters/rabbit_mq/error_worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/error_worker.rb
@@ -15,7 +15,7 @@ module Emque
           def retry_errors
             logger.info "#{log_prefix} starting"
             channel.open if channel.closed?
-            error_queue.message_count.times do
+            [error_queue.message_count, 100].min.times do
               delivery_info, properties, payload = error_queue.pop(
                 {:manual_ack => true}
               )

--- a/lib/emque/consuming/adapters/rabbit_mq/error_worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/error_worker.rb
@@ -56,8 +56,6 @@ module Emque
               ::Emque::Consuming::Consumer.new.consume(:process, message)
               channel.ack(delivery_info.delivery_tag)
             rescue StandardError => exception
-              logger.error "#{log_prefix} #{exception.class}: #{exception.message}"
-              exception.backtrace.each { |bt| logger.error "#{log_prefix} #{bt}" }
               channel.nack(delivery_info.delivery_tag)
             end
           end

--- a/lib/emque/consuming/adapters/rabbit_mq/worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/worker.rb
@@ -79,8 +79,6 @@ module Emque
               ::Emque::Consuming::Consumer.new.consume(:process, message)
               channel.ack(delivery_info.delivery_tag)
             rescue StandardError => exception
-              logger.error "#{log_prefix} #{exception.class}: #{exception.message}"
-              exception.backtrace.each { |bt| logger.error "#{log_prefix} #{bt}" }
               if enable_delayed_message
                 begin
                   publish_to_delayed_message(delivery_info, metadata, payload)

--- a/lib/emque/consuming/consumer/common.rb
+++ b/lib/emque/consuming/consumer/common.rb
@@ -27,7 +27,7 @@ module Emque
         def pipe_config
           @pipe_config ||= Pipe::Config.new(
             :error_handlers => [method(:handle_error)],
-            :raise_on_error => false,
+            :raise_on_error => true,
             :stop_on => ->(msg, _, _) { !(msg.respond_to?(:continue?) && msg.continue?) }
           )
         end

--- a/lib/emque/consuming/version.rb
+++ b/lib/emque/consuming/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Consuming
-    VERSION = "1.5.0"
+    VERSION = "1.6.0"
   end
 end


### PR DESCRIPTION
The features that allow for automatic retries of errors and then sending to the error queue when retries are done does not work with the the raise disabled.