### PR TITLE
Fix retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Emque Consuming CHANGELOG
 
-- [When retrying errors, publish them to their queues in order to provide retry concurrency](https://github.com/emque/emque-consuming/pull/76) 1.8.0
+- [When retrying errors, re-publish them to their original queues in order to provide retry concurrency](https://github.com/emque/emque-consuming/pull/76) 1.8.0
 - [Update Rake to fix CVE-2020-8130](https://github.com/emque/emque-consuming/pull/80) (1.7.1)
 - [Update pipe-ruby to remove error handling](https://github.com/emque/emque-consuming/pull/78) 1.7.0
 - [Fixes bug with Bunny 2.12 failing when exchange names are symbols](https://github.com/emque/emque-consuming/pull/77) 1.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Emque Consuming CHANGELOG
 
+- [When retrying errors, publish them to their queues in order to provide retry concurrency](https://github.com/emque/emque-consuming/pull/76) 1.8.0
 - [Update Rake to fix CVE-2020-8130](https://github.com/emque/emque-consuming/pull/80) (1.7.1)
 - [Update pipe-ruby to remove error handling](https://github.com/emque/emque-consuming/pull/78) 1.7.0
 - [Fixes bug with Bunny 2.12 failing when exchange names are symbols](https://github.com/emque/emque-consuming/pull/77) 1.6.1

--- a/lib/emque/consuming/adapters/rabbit_mq/delayed_message_worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/delayed_message_worker.rb
@@ -65,8 +65,7 @@ module Emque
               logger.debug "#{log_prefix} payload #{payload}"
               message = Emque::Consuming::Message.new(
                 :original => payload
-              )
-              ::Emque::Consuming::Consumer.new.consume(:process, message)
+              ) ::Emque::Consuming::Consumer.new.consume(:process, message)
               channel.ack(delivery_info.delivery_tag)
             rescue StandardError => exception
               if retryable_errors.any? { |error| exception.class.to_s =~ /#{error}/ }

--- a/lib/emque/consuming/adapters/rabbit_mq/delayed_message_worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/delayed_message_worker.rb
@@ -65,7 +65,8 @@ module Emque
               logger.debug "#{log_prefix} payload #{payload}"
               message = Emque::Consuming::Message.new(
                 :original => payload
-              ) ::Emque::Consuming::Consumer.new.consume(:process, message)
+              )
+              ::Emque::Consuming::Consumer.new.consume(:process, message)
               channel.ack(delivery_info.delivery_tag)
             rescue StandardError => exception
               if retryable_errors.any? { |error| exception.class.to_s =~ /#{error}/ }

--- a/lib/emque/consuming/adapters/rabbit_mq/error_worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/error_worker.rb
@@ -50,10 +50,11 @@ module Emque
             begin
               logger.info "#{log_prefix} processing message #{metadata}"
               logger.debug "#{log_prefix} payload #{payload}"
-              message = Emque::Consuming::Message.new(
-                :original => payload
-              )
-              ::Emque::Consuming::Consumer.new.consume(:process, message)
+              message = Oj.load(payload)
+              topic = message.fetch(:metadata).fetch(:topic)
+              headers = metadata[:headers] || {}
+              x  = channel.default_exchange
+              x.publish(payload, :routing_key => "emque.#{config.app_name}.#{topic}", :headers => headers)
               channel.ack(delivery_info.delivery_tag)
             rescue StandardError => exception
               channel.nack(delivery_info.delivery_tag)

--- a/lib/emque/consuming/adapters/rabbit_mq/error_worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/error_worker.rb
@@ -50,11 +50,16 @@ module Emque
             begin
               logger.info "#{log_prefix} processing message #{metadata}"
               logger.debug "#{log_prefix} payload #{payload}"
+
               message = Oj.load(payload)
               topic = message.fetch(:metadata).fetch(:topic)
               headers = metadata[:headers] || {}
-              x  = channel.default_exchange
-              x.publish(payload, :routing_key => "emque.#{config.app_name}.#{topic}", :headers => headers)
+              channel.default_exchange.publish(
+                payload,
+                :routing_key => "emque.#{config.app_name}.#{topic}",
+                :headers => headers
+              )
+
               channel.ack(delivery_info.delivery_tag)
             rescue StandardError => exception
               channel.nack(delivery_info.delivery_tag)

--- a/lib/emque/consuming/version.rb
+++ b/lib/emque/consuming/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Consuming
-    VERSION = "1.7.1"
+    VERSION = "1.8.0"
   end
 end


### PR DESCRIPTION
Republish failed messages to the queues rather than process directly. For slow consumers, processing directly can take a long time. This update will leverage the existing concurrent workers to spread the load.