### PR TITLE
Fixes bug with Bunny 2.12 failing when exchanges names are symbols

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
-  - 2.3.1
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
 script: bundle exec rake
 notifications:
   recipients:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Emque Consuming CHANGELOG
 
+- [Fixes bug with Bunny 2.12 failing when exchange names are symbols](https://github.com/emque/emque-consuming/pull/77) 1.6.1
 - [Re-enable pipe-ruby `raise_on_error` option to fix automatic retries directing messages to the error queue](https://github.com/emque/emque-consuming/pull/75) 1.6.0
 - [Update the puma gem to allow v3](https://github.com/emque/emque-consuming/pull/72) 1.5.0
 - [Disable pipe-ruby `raise_on_error` option to prevent duplicate erorrs](https://github.com/emque/emque-consuming/pull/74) 1.4.0

--- a/lib/emque/consuming/adapters/rabbit_mq/worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/worker.rb
@@ -31,19 +31,18 @@ module Emque
               channel.prefetch(config.adapter.options[:prefetch])
             end
 
-            self.queue =
-              channel
-                .queue(
-                  "emque.#{config.app_name}.#{topic}",
-                  :durable => config.adapter.options[:durable],
-                  :auto_delete => config.adapter.options[:auto_delete],
-                  :arguments => {
-                    "x-dead-letter-exchange" => "#{config.app_name}.error"
-                  }
-                )
-                .bind(
-                  channel.fanout(topic, :durable => true, :auto_delete => false)
-                )
+            self.queue = channel
+              .queue(
+                "emque.#{config.app_name}.#{topic}",
+                :durable => config.adapter.options[:durable],
+                :auto_delete => config.adapter.options[:auto_delete],
+                :arguments => {
+                  "x-dead-letter-exchange" => "#{config.app_name}.error"
+                }
+              )
+              .bind(
+                channel.fanout(topic.to_s, :durable => true, :auto_delete => false)
+              )
           end
 
           def start

--- a/lib/emque/consuming/adapters/rabbit_mq/worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/worker.rb
@@ -41,7 +41,11 @@ module Emque
                 }
               )
               .bind(
-                channel.fanout(topic.to_s, :durable => true, :auto_delete => false)
+                channel.fanout(
+                  topic.to_s, 
+                  :durable => true, 
+                  :auto_delete => false,
+                 )
               )
           end
 

--- a/lib/emque/consuming/version.rb
+++ b/lib/emque/consuming/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Consuming
-    VERSION = "1.6.0"
+    VERSION = "1.6.1"
   end
 end


### PR DESCRIPTION
After updating the Bunny 2.12, the following error is encountered.

```
2019-08-03 04:17:07 UTC [ERROR] Actor crashed!
NoMethodError: undefined method `gsub' for :assignments:Symbol
	/vendor/bundle/ruby/2.3.0/gems/bunny-2.12.0/lib/bunny/channel.rb:1178:in `exchange_declare'
	/vendor/bundle/ruby/2.3.0/gems/bunny-2.12.0/lib/bunny/exchange.rb:254:in `declare!'
	/vendor/bundle/ruby/2.3.0/gems/bunny-2.12.0/lib/bunny/exchange.rb:87:in `initialize'
	/vendor/bundle/ruby/2.3.0/gems/bunny-2.12.0/lib/bunny/channel.rb:316:in `new'
	/vendor/bundle/ruby/2.3.0/gems/bunny-2.12.0/lib/bunny/channel.rb:316:in `fanout'
	/vendor/bundle/ruby/2.3.0/gems/emque-consuming-1.6.0/lib/emque/consuming/adapters/rabbit_mq/worker.rb:45:in `initialize'
```