### PR TITLE
Fixes CVE-2020-8130

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
   - 2.3.8
-  - 2.4.9
-  - 2.5.7
-  - 2.6.5
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
 script: bundle exec rake
 notifications:
   recipients:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Emque Consuming CHANGELOG
 
+- [Update Rake to fix CVE-2020-8130](https://github.com/emque/emque-consuming/pull/80) (1.7.1)
 - [Update pipe-ruby to remove error handling](https://github.com/emque/emque-consuming/pull/78) 1.7.0
 - [Fixes bug with Bunny 2.12 failing when exchange names are symbols](https://github.com/emque/emque-consuming/pull/77) 1.6.1
 - [Re-enable pipe-ruby `raise_on_error` option to fix automatic retries directing messages to the error queue](https://github.com/emque/emque-consuming/pull/75) 1.6.0

--- a/emque-consuming.gemspec
+++ b/emque-consuming.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "inflecto",  "~> 0.0.2"
 
   spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake",    "~> 10.4.2"
+  spec.add_development_dependency "rake",    ">= 12.3.3"  
   spec.add_development_dependency "rspec",   "~> 3.3"
   spec.add_development_dependency "bunny",   "~> 2.11.0"
   spec.add_development_dependency "timecop", "~> 0.7.1"

--- a/lib/emque/consuming/version.rb
+++ b/lib/emque/consuming/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Consuming
-    VERSION = "1.7.0"
+    VERSION = "1.7.1"
   end
 end


### PR DESCRIPTION
Bump Rake requirement to fix CVE-2020-8130 (https://github.com/advisories/GHSA-jppv-gw3r-w3q8)