### PR TITLE
Delayed prefetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Emque Consuming CHANGELOG
 
+- [Add prefetch for DelayedMessageWorker](https://github.com/emque/emque-consuming/pull/81) (1.8.0)
 - [Update Rake to fix CVE-2020-8130](https://github.com/emque/emque-consuming/pull/80) (1.7.1)
 - [Update pipe-ruby to remove error handling](https://github.com/emque/emque-consuming/pull/78) 1.7.0
 - [Fixes bug with Bunny 2.12 failing when exchange names are symbols](https://github.com/emque/emque-consuming/pull/77) 1.6.1

--- a/lib/emque/consuming/adapters/rabbit_mq/delayed_message_worker.rb
+++ b/lib/emque/consuming/adapters/rabbit_mq/delayed_message_worker.rb
@@ -18,6 +18,10 @@ module Emque
           def initialize(connection)
             self.channel = connection.create_channel
 
+            if config.adapter.options[:prefetch]
+              channel.prefetch(config.adapter.options[:prefetch])
+            end
+
             self.delayed_message_exchange = channel.exchange(
               "emque.#{config.app_name}.delayed_message",
               {

--- a/lib/emque/consuming/version.rb
+++ b/lib/emque/consuming/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Consuming
-    VERSION = "1.7.1"
+    VERSION = "1.8.0"
   end
 end


### PR DESCRIPTION
Prevents one instance from hogging all of the messages in the queue.