### PR TITLE
Allow newer version of OJ

### DIFF
--- a/emque-consuming.gemspec
+++ b/emque-consuming.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "celluloid", "0.16.0"
   spec.add_dependency "dante",     "~> 0.2.0"
-  spec.add_dependency "oj",        "~> 2.18.5"
+  spec.add_dependency "oj",        "~> 3.13"
   spec.add_dependency "virtus",    "~> 1.0"
   spec.add_dependency "puma",      "~> 3.12"
   spec.add_dependency "pipe-ruby", "~> 1.0"

--- a/lib/emque/consuming/version.rb
+++ b/lib/emque/consuming/version.rb
@@ -1,5 +1,5 @@
 module Emque
   module Consuming
-    VERSION = "1.9.0"
+    VERSION = "1.9.1"
   end
 end


### PR DESCRIPTION
The OJ dependency has upgraded well beyond 2.18.5. 

Newer versions of Ruby require newer versions of OJ, so to run emque-consuming we need to use newer versions of OJ.